### PR TITLE
Add section about periodic builds to setup-gitea.md

### DIFF
--- a/docs/services/ci/integrations/setup-gitea.md
+++ b/docs/services/ci/integrations/setup-gitea.md
@@ -11,6 +11,13 @@ CodeMC supports hooking into [Gitea](https://about.gitea.com/){ target="_blank" 
 CodeMC allows you to create builds whenever a commit is pushed to your repository.  
 Unlike other Sites is the setup for Gitea/Forgejo a little more complicated and requires some steps on the CI first.
 
+/// warning | Important
+Using this setup will trigger a build no matter the changes or targeted files.  
+It will ignore any exclusion/inclusion settings of the Polling options.
+
+Use the [Periodic Builds](#setup-periodic-builds) setup to avoid this.
+///
+
 1. Login to your account on `https://ci.codemc.io` if you haven't already.
 2. Click your username on the top-right.
 3. Click **Security** on the left-hand side.
@@ -30,3 +37,27 @@ After completing the above steps, head over to your Gitea/Forgejo repository and
     - `Push`
 6. Under **Authorization-Header** put `Basic {code}` where `{code}` is the Base64-encoded text you've created previously.
 7. Press **Add Webhook** to save your new Webhook.
+
+## Setup periodic Builds
+
+If you don't need to have builds made when a commit is pushed can periodic builds be used instead to regularely check your repository for changes and build those.
+
+1.  Login to your account on `https://ci.codemc.io` if you haven't already.
+2.  Head over to your project on CodeMC and open the settings by clicking :octicons-gear-24: **Configure**.
+3.  Under :octicons-git-branch-24: **Source Code Management** make sure that **Git** is selected and that the URL to your repository is configured under **Repository URL**
+    - Make sure that **Branch Specifier (blank for 'any')** is set to the default branch of your repository (Usually `*/master` or `*/main`).
+    - *Optional:* Under **Additional Behaviours** press the **Add** button and add **Polling ignores commits in certain paths** to add settings to define paths that should be included or excluded during a poll.
+4.  Scroll down to the **Build Triggers** section and make sure to check **Poll SCM**
+5.  In the **Schedule** field, add a cron-job-compatible pattern. [crontab.guru]{ target="_blank" rel="nofollow" } can be used to create one.  
+    Please keep the frequency of polls to a reasonable number such as every 15 minutes (`H/15 * * * *`)
+    
+    /// tip
+    `H` should be used instead of `*` when defining a interval for the polling.
+    
+    Using `H` tells the CI to delay the poll should too many other polls already be run at the same time, reducing load on the CI in general.  
+    Note that `H` is not a supported cron-job pattern and specific to the CI. Sites such as [crontab.guru]{ target="_blank" rel="nofollow" } will not support it.
+    ///
+
+6.  Press **Save** to save and apply your changes.
+
+[crontab.guru]: https://crontab.guru/

--- a/docs/services/ci/integrations/setup-gitea.md
+++ b/docs/services/ci/integrations/setup-gitea.md
@@ -12,7 +12,7 @@ CodeMC allows you to create builds whenever a commit is pushed to your repositor
 Unlike other Sites is the setup for Gitea/Forgejo a little more complicated and requires some steps on the CI first.
 
 /// warning | Important
-Using this setup will trigger a build no matter the changes or targeted files.  
+Using this setup will trigger a build, no matter the changes or targeted files.  
 It will ignore any exclusion/inclusion settings of the Polling options.
 
 Use the [Periodic Builds](#setup-periodic-builds) setup to avoid this.
@@ -40,7 +40,7 @@ After completing the above steps, head over to your Gitea/Forgejo repository and
 
 ## Setup periodic Builds
 
-If you don't need to have builds made when a commit is pushed can periodic builds be used instead to regularely check your repository for changes and build those.
+If you don't need to have builds made when a commit is pushed, periodic builds can be used instead to check your repository for changes and build those regularly.
 
 1.  Login to your account on `https://ci.codemc.io` if you haven't already.
 2.  Head over to your project on CodeMC and open the settings by clicking :octicons-gear-24: **Configure**.
@@ -49,7 +49,7 @@ If you don't need to have builds made when a commit is pushed can periodic build
     - *Optional:* Under **Additional Behaviours** press the **Add** button and add **Polling ignores commits in certain paths** to add settings to define paths that should be included or excluded during a poll.
 4.  Scroll down to the **Build Triggers** section and make sure to check **Poll SCM**
 5.  In the **Schedule** field, add a cron-job-compatible pattern. [crontab.guru]{ target="_blank" rel="nofollow" } can be used to create one.  
-    Please keep the frequency of polls to a reasonable number such as every 15 minutes (`H/15 * * * *`)
+    Please keep the frequency of polls to a reasonable number such as every 15 minutes (`H/15 * * * *`). Cron jobs that make excessive calls will be removed.
     
     /// tip
     `H` should be used instead of `*` when defining a interval for the polling.


### PR DESCRIPTION
Updates the `setup-gitea.md` page to add some note about the automatic builds ignoring poll settings and also a section explaining to add periodic polling.