### PR TITLE
Fix a typo

### DIFF
--- a/docs/services/nexus/deploy.md
+++ b/docs/services/nexus/deploy.md
@@ -83,7 +83,7 @@ plugins {
 // Other content (Group, version, ...)
 
 publishing {
-    publication {
+    publications {
         mavenJava(MavenPublication) {
             groupId = project.group
             artifactId = "projectname"


### PR DESCRIPTION
Here should be `publications`

https://github.com/CodeMC/Documentation/blob/eca5a75d669aac5acd479319a129b43b7bf130ea/docs/services/nexus/deploy.md?plain=1#L86